### PR TITLE
Display only job listings on results page.

### DIFF
--- a/tbd-fe/src/components/JobListing/JobListing.scss
+++ b/tbd-fe/src/components/JobListing/JobListing.scss
@@ -1,12 +1,13 @@
 @import '../../assets/variables.scss';
 
 .job {
-    box-shadow: 1px 1px 8px #B2D1E4;
-    height: 421px;
+    background-color: white;
+    box-shadow: 7px 7px 8px #B2D1E4;
+    height: 270px;
     margin-bottom: 20px;
     padding: 20px;
     font-size: $small-text;
-    width: 300px;
+    width: 40%;
     * {
         margin: 8.5px 0;
     }

--- a/tbd-fe/src/containers/App/App.js
+++ b/tbd-fe/src/containers/App/App.js
@@ -3,7 +3,7 @@ import { Route, Switch, Link } from 'react-router-dom';
 import ResultsPage from '../ResultsPage';
 import './App.scss';
 import Form from '../Form/';
-import JobListingContainer from '../../components/JobListingContainer/JobListingContainer';
+// import JobListingContainer from '../../components/JobListingContainer/JobListingContainer';
 
 class App extends Component {
 constructor() {
@@ -17,6 +17,7 @@ constructor() {
     return (
       <Switch>
         <div className="App">
+          <img src='https://wallpapercave.com/wp/wp3594884.jpg' className='result-background'/>
           <Link to='/'>
             <h1>tbd</h1>
           </Link>

--- a/tbd-fe/src/containers/App/App.scss
+++ b/tbd-fe/src/containers/App/App.scss
@@ -18,3 +18,9 @@ h1 {
     margin: 20px auto;
     width: 30px;
 }
+
+.result-background {
+    position: absolute;
+    opacity: .6;
+    z-index: -10;
+}

--- a/tbd-fe/src/containers/Form/Form.scss
+++ b/tbd-fe/src/containers/Form/Form.scss
@@ -2,6 +2,7 @@
 
 .search-form {
   align-items: center;
+  background-color: white;
   border-radius: 10px;
   box-shadow: 1px 1px 8px #B2D1E4;
   display: grid;

--- a/tbd-fe/src/containers/Form/Form.test.js
+++ b/tbd-fe/src/containers/Form/Form.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
-import Form from './index'
+import {Form, mapDispatchToProps} from './index';
+
 
 describe("Form", () => {
   let wrapper;
@@ -13,13 +14,6 @@ describe("Form", () => {
 
   it('should match snapshot', () => {
     expect(wrapper).toMatchSnapshot();
-  })
-
-  it('state should start with empty strings as default', () => {
-    expect(wrapper.state().keywords).toBe('')
-    expect(wrapper.state().location).toBe('')
-    expect(wrapper.state().radius).toBe('')
-    expect(wrapper.state().salary).toBe('')
   })
 
   it('should update state when user types in form fields', () => {
@@ -56,5 +50,12 @@ describe("Form", () => {
       target: {name: "radius", value: newValue}
     })
     expect(wrapper.state().radius).toEqual(newValue)
+  })
+
+  describe('mapDispatchToProps', () => {
+    it('should retrun a list of parameters', () => {
+      const mockState = { params: { keywords: 'test'}}
+      const 
+    })
   })
 })

--- a/tbd-fe/src/containers/Form/Form.test.js
+++ b/tbd-fe/src/containers/Form/Form.test.js
@@ -52,10 +52,4 @@ describe("Form", () => {
     expect(wrapper.state().radius).toEqual(newValue)
   })
 
-  describe('mapDispatchToProps', () => {
-    it('should retrun a list of parameters', () => {
-      const mockState = { params: { keywords: 'test'}}
-      const 
-    })
-  })
 })

--- a/tbd-fe/src/containers/Form/index.js
+++ b/tbd-fe/src/containers/Form/index.js
@@ -5,7 +5,7 @@ import './Form.scss';
 import { gatherJobs } from '../../actions';
 import { connect } from 'react-redux'
 import { Link } from 'react-router-dom'
-class Form extends Component {
+export class Form extends Component {
 
 
   handleChange = e => {

--- a/tbd-fe/src/containers/ResultsPage/ResultsPage.scss
+++ b/tbd-fe/src/containers/ResultsPage/ResultsPage.scss
@@ -1,10 +1,8 @@
-.results-page {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    justify-items: center;
+.job-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
 }
 
-.job {
-    grid-column-start: 0;
-    margin-left: 100px;
-}
+
+

--- a/tbd-fe/src/containers/ResultsPage/index.js
+++ b/tbd-fe/src/containers/ResultsPage/index.js
@@ -93,10 +93,10 @@ export class ResultsPage extends Component {
                 <section className="job-list">
                     {this.displayJobs()}
                 </section>
-                <section className="city-list">
+                {/* <section className="city-list">
                     {this.props.loading && <img src={loading} />}
                    {!this.props.loading && this.displayCities()}
-                </section>
+                </section> */}
             </main>
         )
     }


### PR DESCRIPTION
## Feature/Bug description
- Only Job Listings show on results page. The City Fetch required an extreme amount of time to load. City fetch to be moved to Job Details and will only fetch the specific city.

- Tests Form updated to be exported so that it is testable.

- Background Image added to app for a more stylistic look

## Areas affected
Form, App, Result Page, Job Listings(Style)

## Code changes/Solution
Results Page only shows job listing and not cities

## Any existing behavior change due to this code change
Results Page only shows job listing and not cities

## Covered by unit tests?
[ ] yes
[X] no
[ ] only manual testing applicable